### PR TITLE
Add support for permitted attrs inheritance

### DIFF
--- a/lib/active_form_model.rb
+++ b/lib/active_form_model.rb
@@ -26,7 +26,7 @@ module ActiveFormModel
     end
 
     def _permitted_args
-      @_permitted_args || []
+      @_permitted_args || (superclass.respond_to?(:_permitted_args) && superclass._permitted_args) || []
     end
   end
 


### PR DESCRIPTION
```ruby
class FooForm < Foo
  permit :foo
end

class BarForm < FooForm
  validates :foo, presence: true
end

BarForm.new(params[:bar]).valid?
```