### PR TITLE
Add support for assign_attributes

### DIFF
--- a/active_form_model.gemspec
+++ b/active_form_model.gemspec
@@ -27,5 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("activesupport")
+  spec.add_dependency("activesupport", ">= 3")
+
+  spec.add_development_dependency("activemodel", ">= 5")
+  spec.add_development_dependency("actionpack", ">= 5")
 end

--- a/active_form_model.gemspec
+++ b/active_form_model.gemspec
@@ -26,4 +26,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_dependency("activesupport")
 end

--- a/lib/active_form_model.rb
+++ b/lib/active_form_model.rb
@@ -1,4 +1,5 @@
 require 'active_form_model/version'
+require 'active_support/concern'
 
 module ActiveFormModel
   class Error < StandardError; end

--- a/lib/active_form_model.rb
+++ b/lib/active_form_model.rb
@@ -40,6 +40,11 @@ module ActiveFormModel
     super(permitted_attrs)
   end
 
+  def assign_attributes(attrs = {})
+    permitted_attrs = permit_attrs(attrs)
+    super(permitted_attrs)
+  end
+
   def permit_attrs(attrs)
     attrs.respond_to?(:permit) ? attrs.send(:permit, self.class._permitted_args) : attrs
   end

--- a/test/active_form_model_test.rb
+++ b/test/active_form_model_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'test_helper'
 
-class ActiveFormModelTest < MiniTest::Test
+class ActiveFormModelTest < Minitest::Test
   class User
     include ActiveModel::Model
     attr_accessor :valid_attribute, :invalid_attribute

--- a/test/active_form_model_test.rb
+++ b/test/active_form_model_test.rb
@@ -1,11 +1,89 @@
+# frozen_string_literal: true
 require 'test_helper'
 
-class ActiveFormModelTest < Minitest::Test
+class ActiveFormModelTest < MiniTest::Test
+  class User
+    include ActiveModel::Model
+    attr_accessor :valid_attribute, :invalid_attribute
+
+    def update(*args)
+      assign_attributes(*args)
+      true
+    end
+  end
+
+  class UserForm < User
+    include ActiveFormModel
+    permit :valid_attribute
+  end
+
+  VALID_VALUE = "foo"
+  INVALID_VALUE = "bar"
+  VALID_INITIAL_VALUE = "qux"
+  INVALID_INITIAL_VALUE = "quz"
+
+  def setup
+    @mixed_hash_params = { valid_attribute: VALID_VALUE, invalid_attribute: INVALID_VALUE }
+    @mixed_strong_params = ActionController::Parameters.new(@mixed_hash_params)
+    @form = UserForm.new(valid_attribute: VALID_INITIAL_VALUE, invalid_attribute: INVALID_INITIAL_VALUE)
+  end
+
   def test_that_it_has_a_version_number
     refute_nil ::ActiveFormModel::VERSION
   end
 
-  def test_it_does_something_useful
-    assert false
+  def test_it_accepts_mixed_hash_params_for_constructor
+    assert_equal @form.valid_attribute, VALID_INITIAL_VALUE
+    assert_equal @form.invalid_attribute, INVALID_INITIAL_VALUE
+  end
+
+  def test_it_accepts_mixed_strong_params_for_constructor
+    @form = UserForm.new(@mixed_strong_params)
+
+    assert_equal @form.valid_attribute, VALID_VALUE
+
+    if @mixed_strong_params.respond_to?(:permit)
+      assert_nil @form.invalid_attribute
+    else
+      assert_equal @form.invalid_attribute, INVALID_VALUE
+    end
+  end
+
+  def test_it_accepts_mixed_hash_params_for_assignment
+    @form.assign_attributes(@mixed_hash_params)
+
+    assert_equal @form.valid_attribute, VALID_VALUE
+    assert_equal @form.invalid_attribute, INVALID_VALUE
+  end
+
+  def test_it_accepts_mixed_strong_params_for_assignment
+    @form.assign_attributes(@mixed_strong_params)
+
+    assert_equal @form.valid_attribute, VALID_VALUE
+
+    if @mixed_strong_params.respond_to?(:permit)
+      assert_equal @form.invalid_attribute, INVALID_INITIAL_VALUE
+    else
+      assert_equal @form.invalid_attribute, INVALID_VALUE
+    end
+  end
+
+  def test_it_accepts_mixed_hash_params_for_update
+    @form.update(@mixed_hash_params)
+
+    assert_equal @form.valid_attribute, VALID_VALUE
+    assert_equal @form.invalid_attribute, INVALID_VALUE
+  end
+
+  def test_it_accepts_mixed_strong_params_for_update
+    @form.update(@mixed_strong_params)
+
+    assert_equal @form.valid_attribute, VALID_VALUE
+
+    if @mixed_strong_params.respond_to?(:permit)
+      assert_equal @form.invalid_attribute, INVALID_INITIAL_VALUE
+    else
+      assert_equal @form.invalid_attribute, INVALID_VALUE
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,10 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "active_support/concern"
+require "active_support/core_ext/module/attribute_accessors"
+require "active_support/core_ext/module/delegation"
+require "action_controller/metal/strong_parameters"
+require "active_model"
+
 require "active_form_model"
 
 require "minitest/autorun"


### PR DESCRIPTION
`initialize` is not always an option...

```ruby
class FooForm < Foo
  permit :foo
  validates :foo, presence: true
end

foo = FooForm.new
# ... some logic ...
foo.assign_attributes(params[:foo])
# ... more logic ...
```