### PR TITLE
fix: revert broken stable API

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class UserSignUpForm < User
   include ActiveFormModel
 
   # list all the permitted params
-  fields :first_name, :email, :password
+  permit :first_name, :email, :password
 
   # add validation if necessary
   # they will be merged with base class' validation

--- a/lib/active_form_model/permittable.rb
+++ b/lib/active_form_model/permittable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/deprecation/reporting'
+require 'active_support/deprecation'
 
 module ActiveFormModel
   module Permittable
@@ -18,14 +18,12 @@ module ActiveFormModel
     end
 
     class_methods do
-      def fields(*args)
+      def permit(*args)
         @_permitted_args = args
       end
 
-      def permit(*args)
-        ActiveSupport::Deprecation.warn('permit is deprecated in favor of fields')
-        @_permitted_args = args
-      end
+      alias_method :fields, :permit
+      deprecate fields: :permit, deprecator: ActiveSupport::Deprecation.new('0.6.0', 'ActiveFormModel')
 
       def _permitted_args
         @_permitted_args || (superclass.respond_to?(:_permitted_args) && superclass._permitted_args) || []

--- a/lib/active_form_model/version.rb
+++ b/lib/active_form_model/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveFormModel
-  VERSION = '0.4.1'
+  VERSION = '0.5.0'
 end

--- a/lib/active_form_model/virtual.rb
+++ b/lib/active_form_model/virtual.rb
@@ -10,7 +10,7 @@ module ActiveFormModel
     class_methods do
       def fields(*attrs)
         send(:attr_accessor, *attrs)
-        super(attrs)
+        permit(*attrs)
       end
     end
   end

--- a/test/support/admin_form.rb
+++ b/test/support/admin_form.rb
@@ -2,5 +2,5 @@
 
 class AdminForm < User
   include ActiveFormModel
-  fields :valid_attribute
+  permit :valid_attribute
 end

--- a/test/support/user_form.rb
+++ b/test/support/user_form.rb
@@ -2,5 +2,5 @@
 
 class UserForm < User
   include ActiveFormModel
-  fields :valid_attribute
+  permit :valid_attribute
 end


### PR DESCRIPTION
Возврат стабильного публичного API. Изменения в 700ff1fe3e18576eb963a27724c10daa3d594bdc его ломают, а также неявно создают проблемы пользователям гема. 