### PR TITLE
fix: using with STI models

### DIFF
--- a/active_form_model.gemspec
+++ b/active_form_model.gemspec
@@ -33,4 +33,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency('actionpack', '>= 5')
   spec.add_development_dependency('activemodel', '>= 5')
+  spec.add_development_dependency('activerecord', '>= 5')
+  spec.add_development_dependency('sqlite3')
 end

--- a/lib/active_form_model/permittable.rb
+++ b/lib/active_form_model/permittable.rb
@@ -6,18 +6,13 @@ module ActiveFormModel
   module Permittable
     extend ActiveSupport::Concern
 
-    included do
-      prepend Prepended
-    end
-
-    module Prepended
-      def initialize(attrs = {})
-        permitted_attrs = permit_attrs(attrs)
-        super(permitted_attrs)
-      end
-    end
-
     class_methods do
+      def new(attrs = nil, &block)
+        attrs = _permit_attrs(attrs) if attrs
+
+        super(attrs, &block)
+      end
+
       def fields(*args)
         @_permitted_args = args
       end
@@ -29,6 +24,10 @@ module ActiveFormModel
 
       def _permitted_args
         @_permitted_args || (superclass.respond_to?(:_permitted_args) && superclass._permitted_args) || []
+      end
+
+      def _permit_attrs(attrs)
+        attrs.respond_to?(:permit) ? attrs.send(:permit, _permitted_args) : attrs
       end
     end
 
@@ -50,7 +49,7 @@ module ActiveFormModel
     private
 
     def permit_attrs(attrs)
-      attrs.respond_to?(:permit) ? attrs.send(:permit, self.class._permitted_args) : attrs
+      self.class._permit_attrs(attrs)
     end
   end
 end

--- a/test/active_form_model_active_record_test.rb
+++ b/test/active_form_model_active_record_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActiveFormModelActiveRecordTest < Minitest::Test
+  def setup
+    @data = { valid_attribute: 'one', invalid_attribute: 'two' }
+    @params = ActionController::Parameters.new(@data)
+    ActiveRecord::Base.connection.execute('DELETE FROM tasks;')
+  end
+
+  def test_permitted_attrs_for_new
+    @form = MicrotaskForm.new(@params)
+    assert { @form.invalid_attribute.nil? }
+    assert { @form.valid_attribute == 'one' }
+  end
+
+  def test_permitted_attrs_for_update
+    @form = MicrotaskForm.create
+    @form.update(@params)
+    assert { @form.invalid_attribute.nil? }
+    assert { @form.valid_attribute == 'one' }
+  end
+
+  def test_permitted_attrs_for_update!
+    @form = MicrotaskForm.create
+    @form.update!(@params)
+    assert { @form.invalid_attribute.nil? }
+    assert { @form.valid_attribute == 'one' }
+  end
+
+  def test_permitted_attrs_for_assign_attributes
+    @form = MicrotaskForm.new
+    @form.assign_attributes(@params)
+    assert { @form.invalid_attribute.nil? }
+    assert { @form.valid_attribute == 'one' }
+  end
+
+  def test_permitted_attrs_for_create
+    @form = MicrotaskForm.create(@params)
+    assert { @form.invalid_attribute.nil? }
+    assert { @form.valid_attribute == 'one' }
+  end
+
+  def test_permitted_attrs_for_create_with_block
+    @form = MicrotaskForm.create(@params) do |task|
+      task.invalid_attribute = 'two'
+    end
+    assert { @form.invalid_attribute == 'two' }
+    assert { @form.valid_attribute == 'one' }
+  end
+
+  def test_setting_inheritance_column
+    @form = MicrotaskForm.new
+    assert { @form.type == 'Microtask' }
+  end
+end

--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+ActiveRecord::Base.establish_connection(
+  adapter: 'sqlite3',
+  database: ':memory:'
+)
+
+ActiveRecord::Schema.define do
+  create_table 'tasks' do |t|
+    t.string 'valid_attribute'
+    t.string 'invalid_attribute'
+    t.string 'type'
+  end
+end

--- a/test/support/microtask.rb
+++ b/test/support/microtask.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Microtask < Task
+end

--- a/test/support/microtask_form.rb
+++ b/test/support/microtask_form.rb
@@ -3,5 +3,5 @@
 class MicrotaskForm < Microtask
   include ActiveFormModel
 
-  fields :valid_attribute
+  permit :valid_attribute
 end

--- a/test/support/microtask_form.rb
+++ b/test/support/microtask_form.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MicrotaskForm < Microtask
+  include ActiveFormModel
+
+  fields :valid_attribute
+end

--- a/test/support/task.rb
+++ b/test/support/task.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Task < ActiveRecord::Base
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/module/delegation'
 require 'action_controller/metal/strong_parameters'
 require 'active_model'
+require 'active_record'
 
 require 'active_form_model'
 
@@ -16,5 +17,9 @@ require_relative 'support/user_form'
 require_relative 'support/admin'
 require_relative 'support/admin_form'
 require_relative 'support/sign_in_form'
+require_relative 'support/task'
+require_relative 'support/microtask'
+require_relative 'support/microtask_form'
+require_relative 'support/database'
 
 require 'minitest/autorun'


### PR DESCRIPTION
Hello guys. This PR allows to nest ActiveFormModel forms from AR models with STI column.

I have an error trying to use this gem with STI models like that:

```ruby
class User < ActiveRecord::Base
end

class Client < User
end

class SignUpForm < Client
  include ActiveFormModel
end

SignUpForm.new
```

Exception:

```
ActionController::UnfilteredParameters: unable to convert unpermitted parameters to hash

.../actionpack-6.1.4/lib/action_controller/metal/strong_parameters.rb:316:in `to_h'
.../activerecord-6.1.4/lib/active_record/inheritance.rb:278:in `subclass_from_attributes'
.../activerecord-6.1.4/lib/active_record/inheritance.rb:58:in `new'
```

That's happened because Rails redefines a `.new` method in [active_record/inheritance.rb](https://github.com/rails/rails/blob/v6.1.4/activerecord/lib/active_record/inheritance.rb#L58) to find a subclass from `attributes` passed to `Model.new`. So `#initialize` method is not yet called here and we have unpermitted params. 

Permitting params in `.new` instead of `#initialize` fixes this issue. Please tell me if you see any drawbacks with this approach.
