### PR TITLE
Allow adding permitted args on each level of form inheritance

### DIFF
--- a/lib/active_form_model/permittable.rb
+++ b/lib/active_form_model/permittable.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 require 'active_support/deprecation'
+require 'active_support/core_ext/class/attribute'
 
 module ActiveFormModel
   module Permittable
     extend ActiveSupport::Concern
+
+    included do
+      class_attribute(:_permitted_args, instance_predicate: false, default: [])
+    end
 
     class_methods do
       def new(attrs = nil, &block)
@@ -14,15 +19,11 @@ module ActiveFormModel
       end
 
       def permit(*args)
-        @_permitted_args = args
+        self._permitted_args = _permitted_args | args
       end
 
       alias_method :fields, :permit
       deprecate fields: :permit, deprecator: ActiveSupport::Deprecation.new('0.6.0', 'ActiveFormModel')
-
-      def _permitted_args
-        @_permitted_args || (superclass.respond_to?(:_permitted_args) && superclass._permitted_args) || []
-      end
 
       def _permit_attrs(attrs)
         attrs.respond_to?(:permit) ? attrs.send(:permit, _permitted_args) : attrs

--- a/test/active_form_model_test.rb
+++ b/test/active_form_model_test.rb
@@ -28,6 +28,12 @@ class ActiveFormModelTest < Minitest::Test
     assert { @form.valid_attribute == :one }
   end
 
+  def test_permitted_attrs_for_inhereted_form
+    @form = UnsafeUserForm.new(@params)
+    assert { @form.valid_attribute == :one }
+    assert { @form.invalid_attribute == :two }
+  end
+
   # def test_permitted_attrs_for_update!
   #   @form = UserForm.new
   #   @form.update!(@params)

--- a/test/support/unsafe_user_form.rb
+++ b/test/support/unsafe_user_form.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class UnsafeUserForm < UserForm
+  permit :invalid_attribute
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ require 'active_form_model'
 
 require_relative 'support/user'
 require_relative 'support/user_form'
+require_relative 'support/unsafe_user_form'
 require_relative 'support/admin'
 require_relative 'support/admin_form'
 require_relative 'support/sign_in_form'


### PR DESCRIPTION
Using `class_attrubute :_permitted_args` instead of `@_permitted_args = ...` allows inheriting permitted args from a parent form, and then adding permitted args in a child form.

Although this commit change `permit :arg` behaviour for inherited forms I guess this is more expected.
